### PR TITLE
Use Git notes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,9 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 2.6
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+

--- a/lib/gotsha.rb
+++ b/lib/gotsha.rb
@@ -8,8 +8,8 @@ module Gotsha
   class NoCommandConfigured < StandardError; end
 
   CONFIG_DIR = ".gotsha"
-  COMMANDS_FILE = "#{CONFIG_DIR}/commands".freeze
-  LAST_SUCCESS_FILE = "#{CONFIG_DIR}/last_success".freeze
+  COMMANDS_FILE = "#{CONFIG_DIR}/commands"
+  LAST_SUCCESS_FILE = "#{CONFIG_DIR}/last_success"
 
   # Main entry
   class CLI
@@ -65,7 +65,11 @@ module Gotsha
     end
 
     def stored_sha
-      @stored_sha ||= File.read(LAST_SUCCESS_FILE).strip rescue nil
+      @stored_sha ||= begin
+        File.read(LAST_SUCCESS_FILE).strip
+      rescue StandardError
+        nil
+      end
     end
 
     def last_commit_sha

--- a/lib/gotsha.rb
+++ b/lib/gotsha.rb
@@ -25,7 +25,14 @@ module Gotsha
       FileUtils.mkdir_p(CONFIG_DIR)
       FileUtils.touch(COMMANDS_FILE)
 
-      puts "Done"
+      puts "Configure git notes to store Gotsha checks..."
+      Kernel.system("git config --local notes.displayRef refs/notes/gotsha")
+
+      # fetch/push just gotsha notes
+      Kernel.system("git config --local --add remote.origin.fetch 'refs/notes/gotsha:refs/notes/gotsha'")
+      Kernel.system("git config --local --add remote.origin.push  'refs/notes/gotsha'")
+
+      puts "✓ Done"
     end
 
     def run

--- a/lib/gotsha.rb
+++ b/lib/gotsha.rb
@@ -47,29 +47,19 @@ module Gotsha
     end
 
     def verify
-      if checked?
-        puts "✓ gotsha: HEAD matches #{stored_sha}"
+      if last_comment_note == "ok"
+        puts "✓ gotsha: #{last_commit_sha} verified"
         exit 0
       else
-        puts "✗ gotsha: HEAD=#{last_commit_sha} != stored=#{stored_sha.inspect}"
+        puts "✗ gotsha: #{last_commit_sha} was not verified"
         exit 1
       end
     end
 
     private
 
-    def checked?
-      return false unless File.exist?(LAST_SUCCESS_FILE)
-
-      stored_sha == last_commit_sha
-    end
-
-    def stored_sha
-      @stored_sha ||= begin
-        File.read(LAST_SUCCESS_FILE).strip
-      rescue StandardError
-        nil
-      end
+    def last_comment_note
+      `git notes --ref=gotsha show #{last_commit_sha} 2>/dev/null`.strip
     end
 
     def last_commit_sha

--- a/lib/gotsha.rb
+++ b/lib/gotsha.rb
@@ -40,12 +40,10 @@ module Gotsha
 
       command = File.read(Gotsha::COMMANDS_FILE)
 
-      if Kernel.system(command)
-        puts "YAY, writing commit SHA..."
-        File.write(LAST_SUCCESS_FILE, last_commit_sha)
-      else
-        puts "FUCK"
-      end
+      return unless Kernel.system(command)
+
+      Kernel.system("git notes --ref=gotsha add -f -m 'ok'")
+      puts "✅ gotsha: verified for #{last_commit_sha}"
     end
 
     def verify

--- a/lib/gotsha.rb
+++ b/lib/gotsha.rb
@@ -28,9 +28,9 @@ module Gotsha
       puts "Configure git notes to store Gotsha checks..."
       Kernel.system("git config --local notes.displayRef refs/notes/gotsha")
 
-      # fetch/push just gotsha notes
-      Kernel.system("git config --local --add remote.origin.fetch 'refs/notes/gotsha:refs/notes/gotsha'")
+      Kernel.system("git config --local --add remote.origin.push HEAD")
       Kernel.system("git config --local --add remote.origin.push  'refs/notes/gotsha'")
+      Kernel.system("git config --local --add remote.origin.fetch 'refs/notes/gotsha:refs/notes/gotsha'")
 
       puts "✓ Done"
     end

--- a/spec/gotsha_spec.rb
+++ b/spec/gotsha_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Gotsha::CLI do
           .and_return(sha)
 
         expect(Kernel).to receive(:system).with(test_command).and_return(true)
-        expect(File).to receive(:write).with(Gotsha::LAST_SUCCESS_FILE, sha)
+        expect(Kernel).to receive(:system).with("git notes --ref=gotsha add -f -m 'ok'").and_return(true)
 
         described_class.call(:run)
       end

--- a/spec/gotsha_spec.rb
+++ b/spec/gotsha_spec.rb
@@ -2,6 +2,7 @@
 
 require "fileutils"
 
+# rubocop:disable Metrics/BlockLength:
 RSpec.describe Gotsha::CLI do
   describe "init" do
     it "sets up .gotsha/commands file" do
@@ -9,7 +10,11 @@ RSpec.describe Gotsha::CLI do
       expect(FileUtils).to receive(:touch).with(".gotsha/commands")
 
       expect(Kernel).to receive(:system).with("git config --local notes.displayRef refs/notes/gotsha")
-      expect(Kernel).to receive(:system).with("git config --local --add remote.origin.fetch 'refs/notes/gotsha:refs/notes/gotsha'")
+
+      expect(Kernel).to receive(:system).with(
+        "git config --local --add remote.origin.fetch 'refs/notes/gotsha:refs/notes/gotsha'"
+      )
+
       expect(Kernel).to receive(:system).with("git config --local --add remote.origin.push  'refs/notes/gotsha'")
 
       described_class.call(:init)
@@ -41,7 +46,7 @@ RSpec.describe Gotsha::CLI do
 
     context "with a test command configured" do
       let(:test_command) { "rails t" }
-      let(:sha) { 'test-sha' }
+      let(:sha) { "test-sha" }
 
       before do
         expect(File)
@@ -65,4 +70,5 @@ RSpec.describe Gotsha::CLI do
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength:
 end

--- a/spec/gotsha_spec.rb
+++ b/spec/gotsha_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Gotsha::CLI do
       expect(Kernel).to receive(:system).with("git config --local notes.displayRef refs/notes/gotsha")
 
       expect(Kernel).to receive(:system).with(
+        "git config --local --add remote.origin.push HEAD"
+      )
+
+      expect(Kernel).to receive(:system).with(
         "git config --local --add remote.origin.fetch 'refs/notes/gotsha:refs/notes/gotsha'"
       )
 

--- a/spec/gotsha_spec.rb
+++ b/spec/gotsha_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Gotsha::CLI do
       expect(FileUtils).to receive(:mkdir_p).with(".gotsha")
       expect(FileUtils).to receive(:touch).with(".gotsha/commands")
 
+      expect(Kernel).to receive(:system).with("git config --local notes.displayRef refs/notes/gotsha")
+      expect(Kernel).to receive(:system).with("git config --local --add remote.origin.fetch 'refs/notes/gotsha:refs/notes/gotsha'")
+      expect(Kernel).to receive(:system).with("git config --local --add remote.origin.push  'refs/notes/gotsha'")
+
       described_class.call(:init)
     end
   end


### PR DESCRIPTION
Instead of storing the verification into a file that needs to be commited, let's rather use Git notes.