### PR TITLE
Use the active Ruby environment for configured checks

### DIFF
--- a/lib/gotsha/bash_command.rb
+++ b/lib/gotsha/bash_command.rb
@@ -18,7 +18,7 @@ module Gotsha
       exit_code = nil
 
       # This block is an ugly workaround to ensure the color output is stored both on Linux and Mac
-      PTY.spawn("bash", "-lc", "#{command}; printf \"\\n#{MARKER}%d\\n\" $?") do |r, _w, pid|
+      PTY.spawn("bash", "-c", "#{command}; printf \"\\n#{MARKER}%d\\n\" $?") do |r, _w, pid|
         r.each do |line|
           if line.start_with?(MARKER)
             exit_code = line.sub(MARKER, "").to_i


### PR DESCRIPTION
Configured commands should run in the same environment that launched `gotsha`. Re-entering a login shell can change PATH and Ruby selection, which is reproducible on macOS and made `rubocop` fail with a gem lookup error.